### PR TITLE
Azure Event Hub integration with Birthday Bot

### DIFF
--- a/birthday-bot/Birthday-Bot.csproj
+++ b/birthday-bot/Birthday-Bot.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Bot.Builder.Adapters.Slack" Version="4.9.3-preview" />

--- a/birthday-bot/Bots/ProactiveBot.cs
+++ b/birthday-bot/Bots/ProactiveBot.cs
@@ -58,10 +58,10 @@ namespace Birthday_Bot
             await _oStore.SaveAsync(JsonConvert.SerializeObject(conversationState));
         }
 
-        protected override Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        protected override async Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            AddConversationReference(turnContext.Activity as Activity);
-            return base.OnConversationUpdateActivityAsync(turnContext, cancellationToken);
+            await AddConversationReference(turnContext.Activity as Activity);
+            await base.OnConversationUpdateActivityAsync(turnContext, cancellationToken);            
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
@@ -70,7 +70,5 @@ namespace Birthday_Bot
             await AddConversationReference(turnContext.Activity as Activity);
             return;
         }
-
-
     }
 }

--- a/birthday-bot/Controllers/NotifyController.cs
+++ b/birthday-bot/Controllers/NotifyController.cs
@@ -106,6 +106,7 @@ namespace Birthday_Bot.Controllers
                     await ((BotAdapter)_adapter).ContinueConversationAsync(_appId, _specificChannelConversationRef, BotCallback, default(CancellationToken));
                 }
             }
+
             // Let the caller know proactive messages have been sent
             return new ContentResult()
             {
@@ -118,14 +119,7 @@ namespace Birthday_Bot.Controllers
         private async Task BotCallback(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             await turnContext.SendActivityAsync(happyBirthdayMessage);
-            try
-            {
-                await _eventProducer.SendEventsAsync(happyBirthdayMessage);
-            }
-            catch(Exception ex)
-            {
-                throw ex;
-            }
+            await _eventProducer.SendEventsAsync(happyBirthdayMessage);
         }
     }
 }

--- a/birthday-bot/Events/AzureEventHubProducer.cs
+++ b/birthday-bot/Events/AzureEventHubProducer.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace Birthday_Bot.Events
 
                 var customEvent = new CustomEventData(_userId, message);
 
-                events.Add(new EventData(Encoding.UTF8.GetBytes(message)));
+                events.Add(new EventData(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(customEvent))));
 
                 await producerClient.SendAsync(events);
             }

--- a/birthday-bot/Events/AzureEventHubProducer.cs
+++ b/birthday-bot/Events/AzureEventHubProducer.cs
@@ -11,17 +11,29 @@ namespace Birthday_Bot.Events
     {
         private readonly string _eventHubConnectionString;
         private readonly string _eventHubName;
+        private readonly string _userId;
 
         public AzureEventHubProducer(IConfiguration configuration)
         {
             _eventHubConnectionString = configuration["EventHubConnectionString"];
             _eventHubName = configuration["EventHubName"];
+            _userId = configuration["UserId"];
         }
+
         public async Task SendEventsAsync(string message)
         {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                // Do not send empty meesages to the Event Hub
+                // TODO: Define if we should log something heres
+                return;
+            }
+
             await using (var producerClient = new EventHubProducerClient(_eventHubConnectionString, _eventHubName))
             {
                 List<EventData> events = new List<EventData>();
+
+                var customEvent = new CustomEventData(_userId, message);
 
                 events.Add(new EventData(Encoding.UTF8.GetBytes(message)));
 

--- a/birthday-bot/Events/AzureEventHubProducer.cs
+++ b/birthday-bot/Events/AzureEventHubProducer.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 
 namespace Birthday_Bot.Events
 {
-    public class EventHubProducer : IEventProducer
+    public class AzureEventHubProducer : IEventProducer
     {
         private readonly string _eventHubConnectionString;
         private readonly string _eventHubName;
 
-        public EventHubProducer(IConfiguration configuration)
+        public AzureEventHubProducer(IConfiguration configuration)
         {
             _eventHubConnectionString = configuration["EventHubConnectionString"];
             _eventHubName = configuration["EventHubName"];

--- a/birthday-bot/Events/CustomEventData.cs
+++ b/birthday-bot/Events/CustomEventData.cs
@@ -1,0 +1,14 @@
+﻿namespace Birthday_Bot.Events
+{
+    public class CustomEventData
+    {
+        public CustomEventData(string userId, string message)
+        {
+            UserId = userId;
+            Message = message;
+        }
+
+        public string UserId { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/birthday-bot/Events/EventHubProducer.cs
+++ b/birthday-bot/Events/EventHubProducer.cs
@@ -1,0 +1,32 @@
+﻿using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Birthday_Bot.Events
+{
+    public class EventHubProducer : IEventProducer
+    {
+        private readonly string _eventHubConnectionString;
+        private readonly string _eventHubName;
+
+        public EventHubProducer(IConfiguration configuration)
+        {
+            _eventHubConnectionString = configuration["EventHubConnectionString"];
+            _eventHubName = configuration["EventHubName"];
+        }
+        public async Task SendEventsAsync(string message)
+        {
+            await using (var producerClient = new EventHubProducerClient(_eventHubConnectionString, _eventHubName))
+            {
+                List<EventData> events = new List<EventData>();
+
+                events.Add(new EventData(Encoding.UTF8.GetBytes(message)));
+
+                await producerClient.SendAsync(events);
+            }
+        }
+    }
+}

--- a/birthday-bot/Events/IEventProducer.cs
+++ b/birthday-bot/Events/IEventProducer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Birthday_Bot.Events
 {

--- a/birthday-bot/Events/IEventProducer.cs
+++ b/birthday-bot/Events/IEventProducer.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Birthday_Bot.Events
+{
+    public interface IEventProducer
+    {
+        Task SendEventsAsync(string message);
+    }
+}

--- a/birthday-bot/Startup.cs
+++ b/birthday-bot/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Birthday_Bot.Events;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
@@ -25,6 +26,9 @@ namespace Birthday_Bot
 
             // Create the storage where we'll be using for the Conversation Reference.
             services.AddSingleton<IOStore, BlobContainerConversationStore>();
+
+            // Create an event producer to send proactive messages
+            services.AddSingleton<IEventProducer, EventHubProducer>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, Birthday_Bot>();

--- a/birthday-bot/Startup.cs
+++ b/birthday-bot/Startup.cs
@@ -28,7 +28,7 @@ namespace Birthday_Bot
             services.AddSingleton<IOStore, BlobContainerConversationStore>();
 
             // Create an event producer to send proactive messages
-            services.AddSingleton<IEventProducer, EventHubProducer>();
+            services.AddSingleton<IEventProducer, AzureEventHubProducer>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, Birthday_Bot>();

--- a/birthday-bot/appsettings.json
+++ b/birthday-bot/appsettings.json
@@ -9,5 +9,7 @@
   "BlobStorageConversationContainer": "",
   "BlobStorageDataUsersContainer": "",
   "BambooHRUsersFileName": "",
-  "StorageMethod": "JSON"
+  "StorageMethod": "JSON",
+  "EventHubConnectionString": "",
+  "EventHubName": ""
 }

--- a/birthday-bot/appsettings.json
+++ b/birthday-bot/appsettings.json
@@ -11,5 +11,6 @@
   "BambooHRUsersFileName": "",
   "StorageMethod": "JSON",
   "EventHubConnectionString": "",
-  "EventHubName": ""
+  "EventHubName": "",
+  "EnabledNotifications": []
 }

--- a/birthday-bot/appsettings.json
+++ b/birthday-bot/appsettings.json
@@ -12,5 +12,6 @@
   "StorageMethod": "JSON",
   "EventHubConnectionString": "",
   "EventHubName": "",
-  "EnabledNotifications": []
+  "EnabledNotifications": [],
+  "UserId": ""
 }


### PR DESCRIPTION
## Description
Necessary changes to let the Birthday-Bot publish events on the Azure Event Hub to achieve proactive messaging in the future.

## Specific Changes

  - Create `IEventProducer `interface and `AzureEventHubProducer` implementation.
  - Integrate `AzureEventHubProducer` into `NotifyController` to send events along with Slack greetings.
  - Accommodate `OnConversationUpdateActivityAsync` async call
