### PR TITLE
♻️ Change EventData.Key to be Slack ChannelD

### DIFF
--- a/birthday-bot/Controllers/NotifyController.cs
+++ b/birthday-bot/Controllers/NotifyController.cs
@@ -103,7 +103,9 @@ namespace Birthday_Bot.Controllers
         }
         private async Task SendBirthdayMessageToQueue()
         {
-            await _queueProducer.SendMessageAsync(happyBirthdayMessage);
+            var _specificChannelID = await SlackInterop.GetChannelIdByNameAsync(_specificChannelName, _slackBotToken);
+
+            await _queueProducer.SendMessageAsync(_specificChannelID, happyBirthdayMessage);
         }
         private async Task SendBirthdayMessagesToSlack()
         {

--- a/birthday-bot/Services/Events/CustomEventData.cs
+++ b/birthday-bot/Services/Events/CustomEventData.cs
@@ -2,13 +2,13 @@
 {
     public class CustomEventData
     {
-        public CustomEventData(string userId, string message)
+        public CustomEventData(string key, string message)
         {
-            UserId = userId;
+            Key = key;
             Message = message;
         }
 
-        public string UserId { get; set; }
+        public string Key { get; set; }
         public string Message { get; set; }
     }
 }

--- a/birthday-bot/Services/Queue/IQueueProducer.cs
+++ b/birthday-bot/Services/Queue/IQueueProducer.cs
@@ -5,6 +5,6 @@ namespace Birthday_Bot.Queue
 {
     public interface IQueueProducer
     {
-        Task SendMessageAsync(string message);
+        Task SendMessageAsync(string key, string message);
     }
 }

--- a/birthday-bot/Services/Queue/QueueProducer.cs
+++ b/birthday-bot/Services/Queue/QueueProducer.cs
@@ -20,7 +20,7 @@ namespace Birthday_Bot.Queue
 
         }
 
-        public async Task SendMessageAsync(string message)
+        public async Task SendMessageAsync(string key, string message)
         {
             if (string.IsNullOrWhiteSpace(message))
             {
@@ -44,7 +44,7 @@ namespace Birthday_Bot.Queue
             }
 
             // Async enqueue the message
-            CustomEventData customQueue = new CustomEventData("azbirthdaybot", message);
+            CustomEventData customQueue = new CustomEventData(key, message);
             string queueMessage = Base64Encode(JsonConvert.SerializeObject(customQueue));
             await queueClient.SendMessageAsync(queueMessage);
             Console.WriteLine($"Message added");


### PR DESCRIPTION
# Description
Using `EventData.Key` as Slack `channelId` for proactive messaging. Removed al references of `specificChannelName`.